### PR TITLE
Fixed Xcode version check for Xcode 10

### DIFF
--- a/src/scripts/check_reqs.js
+++ b/src/scripts/check_reqs.js
@@ -4,7 +4,7 @@ var util = require('util');
 var os = require('os');
 var child_process = require('child_process');
 
-var XCODEBUILD_MIN_VERSION = '7.0';
+var XCODEBUILD_MIN_VERSION = 7.0;
 var XCODEBUILD_NOT_FOUND_MESSAGE = util.format('Please install Xcode version %s or greater from the Mac App Store.', XCODEBUILD_MIN_VERSION);
 var TOOL = 'xcodebuild';
 
@@ -28,7 +28,7 @@ xcode_version.on('close', function (code) {
 		var arr = version_string.match(/^Xcode (\d+\.\d+)/);
 		var ver = arr[1];
 
-		if (os.release() >= '15.0.0' && ver < '7.0') {
+		if (os.release() >= '15.0.0' && ver < XCODEBUILD_MIN_VERSION) {
 			console.log(util.format('You need at least Xcode 7.0 when you are on OS X 10.11 El Capitan (you have version %s)', ver));
 			process.exit(1);
 		}


### PR DESCRIPTION
The pre-installation `check_reqs.js` script was checking the Xcode version against a string `'7.0'`. This failed for Xcode 10 and would not let you install ios-deploy.