### PR TITLE
eslint fixes

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,3 @@
+{
+  "extends": "standard"
+}

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,0 +1,15 @@
+root: true
+
+extends: semistandard
+
+rules:
+  indent:
+    - error
+    - 4
+
+  no-unused-vars:
+    - error
+    - args: after-used
+
+  # excpetions specified in:
+  # - src/scripts/.eslintrc.yml

--- a/package.json
+++ b/package.json
@@ -12,13 +12,19 @@
     "url": "https://github.com/ios-control/ios-deploy"
   },
   "devDependencies": {
-    "jshint": "2.5.8"
+    "eslint": "~4.19.1",
+    "eslint-config-semistandard": "^12.0.1",
+    "eslint-config-standard": "^11.0.0",
+    "eslint-plugin-import": "^2.12.0",
+    "eslint-plugin-node": "^6.0.1",
+    "eslint-plugin-promise": "^3.8.0",
+    "eslint-plugin-standard": "^3.1.0"
   },
   "scripts": {
     "preinstall": "./src/scripts/check_reqs.js && xcodebuild",
     "build-test": "npm run pycompile && xcodebuild -target ios-deploy-lib && xcodebuild test -scheme ios-deploy-tests",
-    "test": "npm run jshint && npm run build-test",
-    "jshint": "node node_modules/jshint/bin/jshint src/scripts/*.js",
+    "eslint": "eslint src/scripts/*.js",
+    "test": "npm run eslint && npm run build-test",
     "pycompile": "python -m py_compile src/scripts/*.py"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   },
   "scripts": {
     "preinstall": "./src/scripts/check_reqs.js && xcodebuild",
-    "test": "npm run pycompile && npm run jshint && xcodebuild -target ios-deploy-lib && xcodebuild test -scheme ios-deploy-tests",
+    "build-test": "npm run pycompile && xcodebuild -target ios-deploy-lib && xcodebuild test -scheme ios-deploy-tests",
+    "test": "npm run jshint && npm run build-test",
     "jshint": "node node_modules/jshint/bin/jshint src/scripts/*.js",
     "pycompile": "python -m py_compile src/scripts/*.py"
   },

--- a/package.json
+++ b/package.json
@@ -6,15 +6,13 @@
   ],
   "description": "launch iOS apps iOS devices from the command line (Xcode 7)",
   "main": "ios-deploy",
-  "scripts": {
-  },
   "bin": "./build/Release/ios-deploy",
   "repository": {
     "type": "git",
     "url": "https://github.com/ios-control/ios-deploy"
   },
   "devDependencies": {
-  	"jshint": "2.5.8"
+    "jshint": "2.5.8"
   },
   "scripts": {
     "preinstall": "./src/scripts/check_reqs.js && xcodebuild",
@@ -27,8 +25,8 @@
     "deploy to iOS device"
   ],
   "bugs": {
-      "url": "https://github.com/phonegap/ios-deploy/issues"
-   },
+    "url": "https://github.com/phonegap/ios-deploy/issues"
+  },
   "author": "Greg Hughes",
   "license": "GPLv3"
 }

--- a/src/scripts/.eslintrc.yml
+++ b/src/scripts/.eslintrc.yml
@@ -10,10 +10,6 @@ rules:
   # TBD easy fix:
   padded-blocks: off
 
-  # TODO resolve:
-  no-mixed-spaces-and-tabs: off
-  no-trailing-spaces: off
-
   # FUTURE TBD:
   handle-callback-err: off
   indent: off

--- a/src/scripts/.eslintrc.yml
+++ b/src/scripts/.eslintrc.yml
@@ -1,0 +1,22 @@
+rules:
+  # common src exception:
+  camelcase: off
+
+  # FUTURE TBD:
+  no-unused-vars:
+    - error
+    - args: none
+
+  # TBD easy fix:
+  padded-blocks: off
+
+  # TODO resolve:
+  no-mixed-spaces-and-tabs: off
+  no-trailing-spaces: off
+
+  # FUTURE TBD:
+  handle-callback-err: off
+  indent: off
+  no-multiple-empty-lines: off
+  no-tabs: off
+  one-var: off

--- a/src/scripts/check_reqs.js
+++ b/src/scripts/check_reqs.js
@@ -34,9 +34,9 @@ xcode_version.on('close', function (code) {
 		}
 
 		if (ver < XCODEBUILD_MIN_VERSION) {
-		    console.log(util.format('%s : %s. (you have version %s)', TOOL, XCODEBUILD_NOT_FOUND_MESSAGE, ver));
+			console.log(util.format('%s : %s. (you have version %s)', TOOL, XCODEBUILD_NOT_FOUND_MESSAGE, ver));
 		}
-		
+
 		if (os.release() >= '15.0.0') { // print the El Capitan warning
 			console.log('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
 			console.log('!!!! WARNING: You are on OS X 10.11 El Capitan or greater, you may need to add the');
@@ -46,7 +46,7 @@ xcode_version.on('close', function (code) {
 			console.log('!!!! WARNING:   https://github.com/phonegap/ios-deploy#os-x-1011-el-capitan');
 			console.log('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
 		}
-		
+
 	}
 	process.exit(code);
 });


### PR DESCRIPTION
- migrate from jshint to eslint
- JavaScript cleanup to resolve:
  - no-trailing-spaces
  - no-mixed-spaces-and-tabs
- package.json fixes proposed in #343 are included in this PR as well

Rationale: jshint does not seem to be properly maintained anymore, resulting in some ugly warning messages.

I would be happy to squash some but not all of the commits proposed here.