### PR TITLE
copy Framework symlinks

### DIFF
--- a/ios-deploy.xcodeproj/project.pbxproj
+++ b/ios-deploy.xcodeproj/project.pbxproj
@@ -291,7 +291,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "mkdir -p \"${PROJECT_DIR}/_Frameworks\"\ncp -r /System/Library/PrivateFrameworks/MobileDevice.framework \"${PROJECT_DIR}/_Frameworks\"";
+			shellScript = "mkdir -p \"${PROJECT_DIR}/_Frameworks\"\ncp -R /System/Library/PrivateFrameworks/MobileDevice.framework \"${PROJECT_DIR}/_Frameworks\"";
 		};
 		3BF32EF41F5A217100E1699B /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -330,7 +330,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "mkdir -p \"${PROJECT_DIR}/_Frameworks\"\ncp -r /System/Library/PrivateFrameworks/MobileDevice.framework \"${PROJECT_DIR}/_Frameworks\"";
+			shellScript = "mkdir -p \"${PROJECT_DIR}/_Frameworks\"\ncp -R /System/Library/PrivateFrameworks/MobileDevice.framework \"${PROJECT_DIR}/_Frameworks\"";
 		};
 		C0CD3D9B1F59DA8300F954DB /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
`cp -r` on OS X tries to copy symlinks as the files they point to
and runs afoul of some broken framework links. The real solution
is probably to update Xcode to fix the links, but this at least
lets them stay broken in peace without breaking the build script
or requiring people to disable SIP.

Addresses https://github.com/ios-control/ios-deploy/issues/346, https://github.com/ios-control/ios-deploy/issues/347, https://github.com/ios-control/ios-deploy/issues/349