### PR TITLE
feat: app output to file

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ If you are *not* using a node version manager like [nvm](https://github.com/crea
         -e, --exists                 check if the app with given bundle_id is installed or not 
         -B, --list_bundle_id         list bundle_id 
         -W, --no-wifi                ignore wifi devices
+        -O, --app_output <file>      redirect ios app output, only works in conjunction with --noninteractive
         --detect_deadlocks <sec>     start printing backtraces for all threads periodically after specific amount of seconds
 
 ## Examples

--- a/src/ios-deploy/ios-deploy.m
+++ b/src/ios-deploy/ios-deploy.m
@@ -1678,6 +1678,14 @@ void device_callback(struct am_device_notification_callback_info *info, void *ar
                 best_device_match = info->dev;
                 CFRetain(best_device_match);
             }
+            break;
+        case ADNCI_MSG_DISCONNECTED:
+        {
+            CFStringRef device_uuid = AMDeviceCopyDeviceIdentifier(info->dev);
+            NSLogOut(@"[....] Disconnected %@", device_uuid);
+            CFRelease(device_uuid);
+            break;
+        }
         default:
             break;
     }

--- a/src/ios-deploy/ios-deploy.m
+++ b/src/ios-deploy/ios-deploy.m
@@ -628,7 +628,11 @@ void write_lldb_prep_cmds(AMDeviceRef device, CFURLRef disk_app_url) {
     CFMutableStringRef pmodule = CFStringCreateMutableCopy(NULL, 0, (CFStringRef)LLDB_FRUITSTRAP_MODULE);
 
     CFRange rangeLLDB = { 0, CFStringGetLength(pmodule) };
-    
+
+    CFStringRef exitcode_error_str = CFStringCreateWithFormat(NULL, NULL, CFSTR("%d"), exitcode_error);
+    CFStringFindAndReplace(pmodule, CFSTR("{exitcode_error}"), exitcode_error_str, rangeLLDB, 0);
+    rangeLLDB.length = CFStringGetLength(pmodule);
+
     CFStringRef exitcode_app_crash_str = CFStringCreateWithFormat(NULL, NULL, CFSTR("%d"), exitcode_app_crash);
     CFStringFindAndReplace(pmodule, CFSTR("{exitcode_app_crash}"), exitcode_app_crash_str, rangeLLDB, 0);
     rangeLLDB.length = CFStringGetLength(pmodule);

--- a/src/ios-deploy/ios-deploy.m
+++ b/src/ios-deploy/ios-deploy.m
@@ -89,6 +89,7 @@ char *args = NULL;
 char *list_root = NULL;
 int _timeout = 0;
 int _detectDeadlockTimeout = 0;
+char const*app_output = "";
 int port = 0;    // 0 means "dynamically assigned"
 CFStringRef last_path = NULL;
 service_conn_t gdbfd;
@@ -634,6 +635,10 @@ void write_lldb_prep_cmds(AMDeviceRef device, CFURLRef disk_app_url) {
     
     CFStringRef detect_deadlock_timeout_str = CFStringCreateWithFormat(NULL, NULL, CFSTR("%d"), _detectDeadlockTimeout);
     CFStringFindAndReplace(pmodule, CFSTR("{detect_deadlock_timeout}"), detect_deadlock_timeout_str, rangeLLDB, 0);
+    rangeLLDB.length = CFStringGetLength(pmodule);
+
+    CFStringRef app_output_str = CFStringCreateWithCString(NULL, app_output, kCFStringEncodingUTF8);
+    CFStringFindAndReplace(pmodule, CFSTR("{app_output}"), app_output_str, rangeLLDB, 0);
     rangeLLDB.length = CFStringGetLength(pmodule);
 
     if (args) {
@@ -1753,6 +1758,7 @@ void usage(const char* app) {
         @"  -e, --exists                 check if the app with given bundle_id is installed or not \n"
         @"  -B, --list_bundle_id         list bundle_id \n"
         @"  -W, --no-wifi                ignore wifi devices\n"
+        @"  -O, --app_output <file>      redirect ios app output, only works in conjunction with --noninteractive\n"
         @"  --detect_deadlocks <sec>     start printing backtraces for all threads periodically after specific amount of seconds\n",
         [NSString stringWithUTF8String:app]);
 }
@@ -1799,12 +1805,13 @@ int main(int argc, char *argv[]) {
         { "exists", no_argument, NULL, 'e'},
         { "list_bundle_id", no_argument, NULL, 'B'},
         { "no-wifi", no_argument, NULL, 'W'},
+        { "app_output", required_argument, NULL, 'O' },
         { "detect_deadlocks", required_argument, NULL, 1000 },
         { NULL, 0, NULL, 0 },
     };
     int ch;
 
-    while ((ch = getopt_long(argc, argv, "VmcdvunNrILeD:R:i:b:a:t:g:x:p:1:2:o:l::w::9::B::W", longopts, NULL)) != -1)
+    while ((ch = getopt_long(argc, argv, "VmcdvunNrILeD:R:i:b:a:t:g:x:p:1:2:o:l::w::9::B::WO:", longopts, NULL)) != -1)
     {
         switch (ch) {
         case 'm':
@@ -1906,6 +1913,9 @@ int main(int argc, char *argv[]) {
             break;
         case 'W':
             no_wifi = true;
+            break;
+        case 'O':
+            app_output = optarg;
             break;
         case 1000:
             _detectDeadlockTimeout = atoi(optarg);

--- a/src/scripts/lldb.py
+++ b/src/scripts/lldb.py
@@ -80,26 +80,38 @@ def autoexit_command(debugger, command, result, internal_dict):
     global listener
     process = lldb.target.process
 
+    appOutput = open('{app_output}', 'w') if '{app_output}' else None
     detectDeadlockTimeout = {detect_deadlock_timeout}
     printBacktraceTime = time.time() + detectDeadlockTimeout if detectDeadlockTimeout > 0 else None
-    
+
     # This line prevents internal lldb listener from processing STDOUT/STDERR messages. Without it, an order of log writes is incorrect sometimes
     debugger.GetListener().StopListeningForEvents(process.GetBroadcaster(), lldb.SBProcess.eBroadcastBitSTDOUT | lldb.SBProcess.eBroadcastBitSTDERR )
 
     event = lldb.SBEvent()
-    
+
     def ProcessSTDOUT():
         stdout = process.GetSTDOUT(1024)
         while stdout:
+            if appOutput:
+                appOutput.write(stdout)
             sys.stdout.write(stdout)
             stdout = process.GetSTDOUT(1024)
 
     def ProcessSTDERR():
         stderr = process.GetSTDERR(1024)
         while stderr:
+            if appOutput:
+                appOutput.write(stderr)
             sys.stdout.write(stderr)
             stderr = process.GetSTDERR(1024)
-    
+
+    def Exit(exitcode):
+        ProcessSTDOUT()
+        ProcessSTDERR()
+        if appOutput:
+            appOutput.close()
+        os._exit(exitcode)
+
     while True:
         if listener.WaitForEvent(1, event) and lldb.SBProcess.EventIsProcessEvent(event):
             state = lldb.SBProcess.GetStateFromEvent(event)
@@ -114,25 +126,20 @@ def autoexit_command(debugger, command, result, internal_dict):
         else:
             state = process.GetState()
 
-        if state != lldb.eStateRunning:
-            # Let's make sure that we drained our streams before exit
-            ProcessSTDOUT()
-            ProcessSTDERR()
-
         if state == lldb.eStateExited:
             sys.stdout.write( '\\nPROCESS_EXITED\\n' )
-            os._exit(process.GetExitStatus())
+            Exit(process.GetExitStatus())
         elif printBacktraceTime is None and state == lldb.eStateStopped:
             sys.stdout.write( '\\nPROCESS_STOPPED\\n' )
             debugger.HandleCommand('bt')
-            os._exit({exitcode_app_crash})
+            Exit({exitcode_app_crash})
         elif state == lldb.eStateCrashed:
             sys.stdout.write( '\\nPROCESS_CRASHED\\n' )
             debugger.HandleCommand('bt')
-            os._exit({exitcode_app_crash})
+            Exit({exitcode_app_crash})
         elif state == lldb.eStateDetached:
             sys.stdout.write( '\\nPROCESS_DETACHED\\n' )
-            os._exit({exitcode_app_crash})
+            Exit({exitcode_app_crash})
         elif printBacktraceTime is not None and time.time() >= printBacktraceTime:
             printBacktraceTime = None
             sys.stdout.write( '\\nPRINT_BACKTRACE_TIMEOUT\\n' )

--- a/src/scripts/lldb.py
+++ b/src/scripts/lldb.py
@@ -55,14 +55,15 @@ def run_command(debugger, command, result, internal_dict):
     #This env variable makes NSLog, CFLog and os_log messages get mirrored to stderr
     #https://stackoverflow.com/a/39581193 
     launchInfo.SetEnvironmentEntries(['OS_ACTIVITY_DT_MODE=enable'], True)
-    
+
     lldb.target.Launch(launchInfo, error)
-    lockedstr = ': Locked'
-    if lockedstr in str(error):
-       print('\\nDevice Locked\\n')
-       os._exit(254)
-    else:
-       print(str(error))
+    if error.Fail():
+        if ': Locked' in str(error):
+            print('\\nDevice Locked\\n')
+        else:
+            print(str(error))
+        #force exit to make sure autoexit or safequit don't end up waiting forever
+        os._exit({exitcode_error})
 
 def safequit_command(debugger, command, result, internal_dict):
     process = lldb.target.process


### PR DESCRIPTION
* Added option "-O" to output app output to a file on the host computer
* Print "Disconnected" message when devices disappear
* Fixes to make sure we don't end up with an LLDB prompt when running in --noninteractive mode