### PR TITLE
sanitize file names that include device_id for iPhone xs series

### DIFF
--- a/src/ios-deploy/ios-deploy.m
+++ b/src/ios-deploy/ios-deploy.m
@@ -691,8 +691,8 @@ void write_lldb_prep_cmds(AMDeviceRef device, CFURLRef disk_app_url) {
 
     NSString* python_command = @"fruitstrap_";
     if(device_id != NULL) {
-        python_file_path = [python_file_path stringByAppendingString:[NSString stringWithUTF8String:device_id]];
-        python_command = [python_command stringByAppendingString:[NSString stringWithUTF8String:device_id]];
+        python_file_path = [python_file_path stringByAppendingString:[[NSString stringWithUTF8String:device_id] stringByReplacingOccurrencesOfString:@"-" withString:@"_"]];
+        python_command = [python_command stringByAppendingString:[[NSString stringWithUTF8String:device_id] stringByReplacingOccurrencesOfString:@"-" withString:@"_"]];
     }
     python_file_path = [python_file_path stringByAppendingString:@".py"];
 
@@ -704,7 +704,7 @@ void write_lldb_prep_cmds(AMDeviceRef device, CFURLRef disk_app_url) {
     CFDataRef cmds_data = CFStringCreateExternalRepresentation(NULL, cmds, kCFStringEncodingUTF8, 0);
     NSString* prep_cmds_path = [NSString stringWithFormat:PREP_CMDS_PATH, tmpUUID];
     if(device_id != NULL) {
-        prep_cmds_path = [prep_cmds_path stringByAppendingString:[NSString stringWithUTF8String:device_id]];
+        prep_cmds_path = [prep_cmds_path stringByAppendingString:[[NSString stringWithUTF8String:device_id] stringByReplacingOccurrencesOfString:@"-" withString:@"_"]];
     }
     FILE *out = fopen([prep_cmds_path UTF8String], "w");
     fwrite(CFDataGetBytePtr(cmds_data), CFDataGetLength(cmds_data), 1, out);
@@ -963,7 +963,7 @@ void launch_debugger(AMDeviceRef device, CFURLRef url) {
         lldb_shell = [NSString stringWithFormat:LLDB_SHELL, prep_cmds];
 
         if(device_id != NULL) {
-            lldb_shell = [lldb_shell stringByAppendingString: [NSString stringWithUTF8String:device_id]];
+            lldb_shell = [lldb_shell stringByAppendingString: [[NSString stringWithUTF8String:device_id] stringByReplacingOccurrencesOfString:@"-" withString:@"_"]];
         }
 
         int status = system([lldb_shell UTF8String]); // launch lldb
@@ -1002,7 +1002,7 @@ void launch_debugger_and_exit(AMDeviceRef device, CFURLRef url) {
         NSString* prep_cmds = [NSString stringWithFormat:PREP_CMDS_PATH, tmpUUID];
         NSString* lldb_shell = [NSString stringWithFormat:LLDB_SHELL, prep_cmds];
         if(device_id != NULL) {
-            lldb_shell = [lldb_shell stringByAppendingString:[NSString stringWithUTF8String:device_id]];
+            lldb_shell = [lldb_shell stringByAppendingString:[[NSString stringWithUTF8String:device_id] stringByReplacingOccurrencesOfString:@"-" withString:@"_"]];
         }
 
         int status = system([lldb_shell UTF8String]); // launch lldb


### PR DESCRIPTION
the device_id of the new iPhone XS series has changed to a 25 digit hexadecimal string with a '-' character for the 9th character. '-' characters aren't allowed to be file names in python so when the autogenerated python files were imported they would fail with a syntax error due to the new device id being in the name. this sanitized the file names to replace the '-' character with a '_'