### PR TITLE
Remove broken XCode version check

### DIFF
--- a/src/scripts/check_reqs.js
+++ b/src/scripts/check_reqs.js
@@ -4,8 +4,7 @@ var util = require('util');
 var os = require('os');
 var child_process = require('child_process');
 
-var XCODEBUILD_MIN_VERSION = 7.0;
-var XCODEBUILD_NOT_FOUND_MESSAGE = util.format('Please install Xcode version %s or greater from the Mac App Store.', XCODEBUILD_MIN_VERSION);
+var XCODEBUILD_NOT_FOUND_MESSAGE = 'Please install Xcode from the Mac App Store.';
 var TOOL = 'xcodebuild';
 
 var xcode_version = child_process.spawn(TOOL, ['-version']),
@@ -28,16 +27,7 @@ xcode_version.on('close', function (code) {
 		var arr = version_string.match(/^Xcode (\d+\.\d+)/);
 		var ver = arr[1];
 
-		if (os.release() >= '15.0.0' && ver < XCODEBUILD_MIN_VERSION) {
-			console.log(util.format('You need at least Xcode 7.0 when you are on OS X 10.11 El Capitan (you have version %s)', ver));
-			process.exit(1);
-		}
-
-		if (ver < XCODEBUILD_MIN_VERSION) {
-			console.log(util.format('%s : %s. (you have version %s)', TOOL, XCODEBUILD_NOT_FOUND_MESSAGE, ver));
-		}
-
-		if (os.release() >= '15.0.0') { // print the El Capitan warning
+		if (parseInt(os.release().split('.')[0]) >= 15) { // print the El Capitan warning
 			console.log('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
 			console.log('!!!! WARNING: You are on OS X 10.11 El Capitan or greater, you may need to add the');
 			console.log('!!!! WARNING:   `--unsafe-perm=true` flag when running `npm install`');

--- a/src/scripts/check_reqs.js
+++ b/src/scripts/check_reqs.js
@@ -24,9 +24,6 @@ xcode_version.on('error', function (err) {
 
 xcode_version.on('close', function (code) {
 	if (code === 0) {
-		var arr = version_string.match(/^Xcode (\d+\.\d+)/);
-		var ver = arr[1];
-
 		if (parseInt(os.release().split('.')[0]) >= 15) { // print the El Capitan warning
 			console.log('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
 			console.log('!!!! WARNING: You are on OS X 10.11 El Capitan or greater, you may need to add the');

--- a/src/scripts/check_reqs.js
+++ b/src/scripts/check_reqs.js
@@ -7,12 +7,7 @@ var child_process = require('child_process');
 var XCODEBUILD_NOT_FOUND_MESSAGE = 'Please install Xcode from the Mac App Store.';
 var TOOL = 'xcodebuild';
 
-var xcode_version = child_process.spawn(TOOL, ['-version']),
-	version_string = '';
-
-xcode_version.stdout.on('data', function (data) {
-	version_string += data;
-});
+var xcode_version = child_process.spawn(TOOL, ['-version']);
 
 xcode_version.stderr.on('data', function (data) {
 	console.log('stderr: ' + data);


### PR DESCRIPTION
It would be very odd for anyone to have XCode 6.X or lower at this point. The current check doesn't handle some cases correctly(#378) and adding proper semantic version checking for this seems excessive.