### PR TITLE
Always send unsigned error codes in JSON

### DIFF
--- a/src/ios-deploy/ios-deploy.m
+++ b/src/ios-deploy/ios-deploy.m
@@ -553,7 +553,7 @@ void mount_developer_image(AMDeviceRef device) {
     CFDictionaryRef options = CFDictionaryCreate(NULL, (const void **)&keys, (const void **)&values, 2, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
     CFRelease(sig_data);
 
-    int result = AMDeviceMountImage(device, image_path, options, &mount_callback, 0);
+    unsigned int result = (unsigned int)AMDeviceMountImage(device, image_path, options, &mount_callback, 0);
     if (result == 0) {
         NSLogOut(@"[ 95%%] Developer disk image mounted successfully");
     } else if (result == 0xe8000076 /* already mounted */) {


### PR DESCRIPTION
The error code being sent for "Device Lock" here was getting sent as -402652958 rather than 3892314338.

Currently  check_error() casts the return to `unsigned int` so also casting the call for image-mounting were correctly sending the expected unsigned value in the JSON; this makes the JSON value for image-mounting issues come through as an unsigned int which can be compared to the hex values that are expected(e.g. 0xe80000e2 = 3892314338, not -402652958 ).