### PR TITLE
Remove node/npm from README installation steps (in favor of brew)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,41 +21,19 @@ The 1.x branch has been archived (renamed for now), all development is to be on 
 
 ## Installation
 
-ios-deploy installation is made simple using the node.js package manager.  If you use [Homebrew](https://brew.sh/), install [node.js](https://nodejs.org):
+If you don't already have it installed, install [Homebrew](https://brew.sh/) and run:
 
 ```
-brew install node
+brew install ios-deploy
 ```
-
-Now install ios-deploy with the [node.js](https://nodejs.org) package manager:
-
-```
-npm install -g ios-deploy
-```
-
-To build from source:
-
-```
-xcodebuild
-```
-
-This will build `ios-deploy` into the `build/Release` folder.
 
 ## Testing
 
 Run:
 
 ```
-npm install && npm test
+python -m py_compile src/scripts/*.py && xcodebuild -target ios-deploy-lib && xcodebuild test -scheme ios-deploy-tests
 ```
-
-### OS X 10.11 El Capitan or greater
-
-If you are *not* using a node version manager like [nvm](https://github.com/creationix/nvm) or [n](https://github.com/tj/n), you may have to do either of these three things below when under El Capitan:
-
-1. Add the `--unsafe-perm=true` flag  when installing ios-deploy
-2. Add the `--allow-root` flag  when installing ios-deploy
-3. Ensure the `nobody` user has write access to `/usr/local/lib/node_modules/ios-deploy/ios-deploy`
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,12 @@ The 1.x branch has been archived (renamed for now), all development is to be on 
 
 ## Installation
 
-If you don't already have it installed, install [Homebrew](https://brew.sh/) and run:
+If you have previously installed ios-deploy via `npm`, uninstall it by running:
+```
+sudo npm uninstall -g ios-deploy
+```
+
+Install ios-deploy via [Homebrew](https://brew.sh/) by running:
 
 ```
 brew install ios-deploy


### PR DESCRIPTION
We aren't abandoning the npm package, there are 37 dependent packages on https://www.npmjs.com/package/ios-deploy that we don't want to break!

**BUT**, with the odd issues in #415 it's prudent to not direct people toward node when they are wanting to install ios-deploy for command line use. Directing users to install ios-deploy via brew cuts down the number of steps and seems to be less flaky.
