### PR TITLE
Add --app_deltas option that can be used to specify a directory to store data to enable incremental installs.

### DIFF
--- a/src/ios-deploy/MobileDevice.h
+++ b/src/ios-deploy/MobileDevice.h
@@ -454,7 +454,6 @@ void AMDAddLogFileDescriptor(int fd);
 
 typedef int (*am_device_install_application_callback)(CFDictionaryRef, int);
 
-mach_error_t AMDeviceInstallApplicationBundle(am_device device, CFStringRef path, CFDictionaryRef options, am_device_install_application_callback callback, void *user);
 mach_error_t AMDeviceInstallApplication(service_conn_t socket, CFStringRef path, CFDictionaryRef options, am_device_install_application_callback callback, void *user);
 mach_error_t AMDeviceTransferApplication(service_conn_t socket, CFStringRef path, CFDictionaryRef options, am_device_install_application_callback callbackj, void *user);
 

--- a/src/ios-deploy/MobileDevice.h
+++ b/src/ios-deploy/MobileDevice.h
@@ -454,6 +454,7 @@ void AMDAddLogFileDescriptor(int fd);
 
 typedef int (*am_device_install_application_callback)(CFDictionaryRef, int);
 
+mach_error_t AMDeviceInstallApplicationBundle(am_device device, CFStringRef path, CFDictionaryRef options, am_device_install_application_callback callback, void *user);
 mach_error_t AMDeviceInstallApplication(service_conn_t socket, CFStringRef path, CFDictionaryRef options, am_device_install_application_callback callback, void *user);
 mach_error_t AMDeviceTransferApplication(service_conn_t socket, CFStringRef path, CFDictionaryRef options, am_device_install_application_callback callbackj, void *user);
 

--- a/src/ios-deploy/ios-deploy.m
+++ b/src/ios-deploy/ios-deploy.m
@@ -615,8 +615,14 @@ mach_error_t install_callback(CFDictionaryRef dict, int arg) {
 
     int overall_percent = (percent / 2) + 50;
 
+    // During standard install, the "Status" value contains the actual status,
+    // such as "Copying" or "CreatingStagingDirectory", as well as any
+    // applicable paths. The incremental install version, includes only the
+    // status and a seperate value in "Path" for any applicable paths. This
+    // merges the status and path during incremental installs so the output is
+    // similar between both installation types.
     CFStringRef path = CFDictionaryGetValue(dict, CFSTR("Path"));
-    NSString *status_with_path = path != NULL ?
+    NSString *status_with_path = (path != NULL && app_deltas != NULL) ?
       [NSString stringWithFormat:@"%@ %@", status, path] :
       (__bridge NSString *)status;
 
@@ -1957,7 +1963,7 @@ int main(int argc, char *argv[]) {
     };
     int ch;
 
-    while ((ch = getopt_long(argc, argv, "A:VmcdvunrILeD:R:i:b:a:t:p:1:2:o:l:w:9BWjNs:OE:C", longopts, NULL)) != -1)
+    while ((ch = getopt_long(argc, argv, "VmcdvunrILeD:R:i:b:a:t:p:1:2:o:l:w:9BWjNs:OE:CA:", longopts, NULL)) != -1)
     {
         switch (ch) {
         case 'm':


### PR DESCRIPTION
This change will leave the standard install as the default option and have no affect on standard installs. Incremental installs needs to be enabled by passing the "--app_deltas" (-A) flag as well as a path to a directory where the mobile device framework will store what it needs to determine what needs has actually changed on a subsequent install.