### PR TITLE
Non-interactive mode

### DIFF
--- a/src/ios-deploy/ios-deploy.m
+++ b/src/ios-deploy/ios-deploy.m
@@ -749,7 +749,11 @@ void write_lldb_prep_cmds(AMDeviceRef device, CFURLRef disk_app_url) {
     CFMutableStringRef pmodule = CFStringCreateMutableCopy(NULL, 0, (CFStringRef)LLDB_FRUITSTRAP_MODULE);
 
     CFRange rangeLLDB = { 0, CFStringGetLength(pmodule) };
-    
+
+    CFStringRef exitcode_error_str = CFStringCreateWithFormat(NULL, NULL, CFSTR("%d"), exitcode_error);
+    CFStringFindAndReplace(pmodule, CFSTR("{exitcode_error}"), exitcode_error_str, rangeLLDB, 0);
+    rangeLLDB.length = CFStringGetLength(pmodule);
+
     CFStringRef exitcode_app_crash_str = CFStringCreateWithFormat(NULL, NULL, CFSTR("%d"), exitcode_app_crash);
     CFStringFindAndReplace(pmodule, CFSTR("{exitcode_app_crash}"), exitcode_app_crash_str, rangeLLDB, 0);
     CFRelease(exitcode_app_crash_str);

--- a/src/scripts/lldb.py
+++ b/src/scripts/lldb.py
@@ -155,24 +155,32 @@ def autoexit_command(debugger, command, result, internal_dict):
             sys.stdout.write( '\\nPROCESS_EXITED\\n' )
             CloseOut()
             os._exit(process.GetExitStatus())
-        elif printBacktraceTime is None and state == lldb.eStateStopped:
-            sys.stdout.write( '\\nPROCESS_STOPPED\\n' )
-            debugger.HandleCommand('bt')
+        elif state == lldb.eStateRunning:
+            if printBacktraceTime is not None and time.time() >= printBacktraceTime:
+                printBacktraceTime = None
+                sys.stdout.write( '\\nPRINT_BACKTRACE_TIMEOUT\\n' )
+                debugger.HandleCommand('process interrupt')
+                debugger.HandleCommand('bt all')
+                debugger.HandleCommand('continue')
+                printBacktraceTime = time.time() + 5
+        elif state == lldb.eStateStepping or state == lldb.eStateConnected:
+            continue
+        elif state == lldb.eStateExited:
+            sys.stdout.write( '\\nPROCESS_EXITED\\n' )
+            CloseOut()
+            os._exit(process.GetExitStatus())
+        else:
+            if state == lldb.eStateStopped:
+                sys.stdout.write( '\\nPROCESS_STOPPED\\n' )
+                debugger.HandleCommand('bt')
+            elif state == lldb.eStateCrashed:
+                sys.stdout.write( '\\nPROCESS_CRASHED\\n' )
+                debugger.HandleCommand('bt')
+            elif state == lldb.eStateDetached:
+                sys.stdout.write( '\\nPROCESS_DETACHED\\n' )
+            else:
+                sys.stdout.write( '\\nPROCESS_\\n' + str(state).upper() )
+                debugger.HandleCommand('bt')
             CloseOut()
             os._exit({exitcode_app_crash})
-        elif state == lldb.eStateCrashed:
-            sys.stdout.write( '\\nPROCESS_CRASHED\\n' )
-            debugger.HandleCommand('bt')
-            CloseOut()
-            os._exit({exitcode_app_crash})
-        elif state == lldb.eStateDetached:
-            sys.stdout.write( '\\nPROCESS_DETACHED\\n' )
-            CloseOut()
-            os._exit({exitcode_app_crash})
-        elif printBacktraceTime is not None and time.time() >= printBacktraceTime:
-            printBacktraceTime = None
-            sys.stdout.write( '\\nPRINT_BACKTRACE_TIMEOUT\\n' )
-            debugger.HandleCommand('process interrupt')
-            debugger.HandleCommand('bt all')
-            debugger.HandleCommand('continue')
-            printBacktraceTime = time.time() + 5
+

--- a/src/scripts/lldb.py
+++ b/src/scripts/lldb.py
@@ -68,8 +68,8 @@ def run_command(debugger, command, result, internal_dict):
        print('\\nDevice Locked\\n')
     else:
        print(str(startup_error))
-        #force exit to make sure autoexit or safequit don't end up waiting forever
-        os._exit({exitcode_error})
+    #force exit to make sure autoexit or safequit don't end up waiting forever
+    os._exit({exitcode_error})
 
 def safequit_command(debugger, command, result, internal_dict):
     process = lldb.target.process

--- a/src/scripts/lldb.py
+++ b/src/scripts/lldb.py
@@ -66,9 +66,10 @@ def run_command(debugger, command, result, internal_dict):
     lockedstr = ': Locked'
     if lockedstr in str(startup_error):
        print('\\nDevice Locked\\n')
-       os._exit(254)
     else:
        print(str(startup_error))
+        #force exit to make sure autoexit or safequit don't end up waiting forever
+        os._exit({exitcode_error})
 
 def safequit_command(debugger, command, result, internal_dict):
     process = lldb.target.process

--- a/src/scripts/lldb.py
+++ b/src/scripts/lldb.py
@@ -63,13 +63,13 @@ def run_command(debugger, command, result, internal_dict):
     launchInfo.SetEnvironmentEntries(envs_arr, True)
     
     lldb.target.Launch(launchInfo, startup_error)
-    lockedstr = ': Locked'
-    if lockedstr in str(startup_error):
-       print('\\nDevice Locked\\n')
-    else:
-       print(str(startup_error))
-    #force exit to make sure autoexit or safequit don't end up waiting forever
-    os._exit({exitcode_error})
+    if startup_error.Fail():
+        if ': Locked' in str(startup_error):
+            print('\\nDevice Locked\\n')
+        else:
+            print(str(startup_error))
+        #force exit to make sure autoexit or safequit don't end up waiting forever
+        os._exit({exitcode_error})
 
 def safequit_command(debugger, command, result, internal_dict):
     process = lldb.target.process
@@ -165,10 +165,6 @@ def autoexit_command(debugger, command, result, internal_dict):
                 printBacktraceTime = time.time() + 5
         elif state == lldb.eStateStepping or state == lldb.eStateConnected:
             continue
-        elif state == lldb.eStateExited:
-            sys.stdout.write( '\\nPROCESS_EXITED\\n' )
-            CloseOut()
-            os._exit(process.GetExitStatus())
         else:
             if state == lldb.eStateStopped:
                 sys.stdout.write( '\\nPROCESS_STOPPED\\n' )


### PR DESCRIPTION
Added an explicit exit on launch failure to ensure auto exit and safe quit don’t end up waiting forever.
Also fixed process state handling to support all states possible.
Based on the work of bitter: commits ebb3d85254ed72f11cdc5333adc99bd1aae59a05 and 4ad2731b077a1e448f2171794f1e36cd8b31617f