### PR TITLE
Fix the error when try to access some apps' sandbox

### DIFF
--- a/src/ios-deploy/ios-deploy.m
+++ b/src/ios-deploy/ios-deploy.m
@@ -1359,8 +1359,18 @@ AFCConnectionRef start_house_arrest_service(AMDeviceRef device) {
     }
 
     CFStringRef cf_bundle_id = CFStringCreateWithCString(NULL, bundle_id, kCFStringEncodingUTF8);
-    if (AMDeviceCreateHouseArrestService(device, cf_bundle_id, 0, &conn) != 0)
-    {
+    CFStringRef keys[1];
+    keys[0] = CFSTR("Command");
+    CFStringRef values[1];
+    values[0] = CFSTR("VendDocuments");
+    CFDictionaryRef command = CFDictionaryCreate(kCFAllocatorDefault,
+                                                 (void*)keys,
+                                                 (void*)values,
+                                                 1,
+                                                 &kCFTypeDictionaryKeyCallBacks,
+                                                 &kCFTypeDictionaryValueCallBacks);
+    if (AMDeviceCreateHouseArrestService(device, cf_bundle_id, 0, &conn) != 0 &&
+        AMDeviceCreateHouseArrestService(device, cf_bundle_id, command, &conn) != 0) {
         on_error(@"Unable to find bundle with id: %@", [NSString stringWithUTF8String:bundle_id]);
     }
 


### PR DESCRIPTION
Fix the error when try to access some apps' sandbox by using a different command to start house arrest service

By default , when starting house arrest service, it will try to get the full access to the container. But most apps only allow the access to Documents directory.   So `start_house_arrest_service` will fail: 
![before the commit ](https://user-images.githubusercontent.com/4402159/72676712-29136680-3acf-11ea-8773-1a7df1066df4.png)

So I try to start house arrest service by default first. If it fails,  then I will try to start again by VendDocuments. Everything is back to normal.
![after the commit](https://user-images.githubusercontent.com/4402159/72676677-ee113300-3ace-11ea-9d0d-4c37d9e6e26f.png)
