### PR TITLE
Add --file_system/-f option that allows to access the raw file system

### DIFF
--- a/src/ios-deploy/ios-deploy.m
+++ b/src/ios-deploy/ios-deploy.m
@@ -1359,8 +1359,18 @@ AFCConnectionRef start_house_arrest_service(AMDeviceRef device) {
     }
 
     CFStringRef cf_bundle_id = CFStringCreateWithCString(NULL, bundle_id, kCFStringEncodingUTF8);
-    if (AMDeviceCreateHouseArrestService(device, cf_bundle_id, 0, &conn) != 0)
-    {
+    CFStringRef keys[1];
+    keys[0] = CFSTR("Command");
+    CFStringRef values[1];
+    values[0] = CFSTR("VendDocuments");
+    CFDictionaryRef command = CFDictionaryCreate(kCFAllocatorDefault,
+                                                 (void*)keys,
+                                                 (void*)values,
+                                                 1,
+                                                 &kCFTypeDictionaryKeyCallBacks,
+                                                 &kCFTypeDictionaryValueCallBacks);
+    if (AMDeviceCreateHouseArrestService(device, cf_bundle_id, 0, &conn) != 0 &&
+        AMDeviceCreateHouseArrestService(device, cf_bundle_id, command, &conn) != 0) {
         on_error(@"Unable to find bundle with id: %@", [NSString stringWithUTF8String:bundle_id]);
     }
 


### PR DESCRIPTION
Now `ios-deploy` only support to access app's sandbox.  But actually iOS allows us to browse some other directories on file system,  like `/DCIM` which contains all the photos in camera roll

So I add `-f`(short for `--file_system`) options to work with 5 existing file related options( `download`/`upload`/`mkdir`/`list`/`rm`) .  

When `-f` option is on,  it means the other 5 options is to access the file system, instead of some app's sandbox. 

The code is simple, `-f` decides whether we should start `afc service` or `house arrest service`.  

Usage:
```
# list the files in cameral roll, a.k.a /DCIM
ios-deploy -f -l/DCIM

# download the file in /DCIM： 
ios-deploy -f -w/DCIM/100APPLE/IMG_001.jpg

# remove the file /DCIM： 
ios-deploy -f -R /DCIM/100APPLE/IMG_001.jpg

# make directoly in /DCIM
ios-deploy -f -D/DCIM/test

# upload file to /DCIM
ios-deploy -f -o/Users/ryan/Downloads/test.png -2/DCIM/test.png
``` 
 