### PR TITLE
Add -F/--non-recursively option that controls whether to walk the directory recursively; add --json support for list_file

### DIFF
--- a/src/ios-deploy/ios-deploy.m
+++ b/src/ios-deploy/ios-deploy.m
@@ -352,7 +352,9 @@ CFStringRef get_device_full_name(const AMDeviceRef device) {
                 device_name = NULL,
                 model_name = NULL,
                 sdk_name = NULL,
-                arch_name = NULL;
+                arch_name = NULL,
+                product_version = NULL,
+                build_version = NULL;
 
     AMDeviceConnect(device);
 
@@ -370,12 +372,16 @@ CFStringRef get_device_full_name(const AMDeviceRef device) {
     model_name = dev.name;
     sdk_name = dev.sdk;
     arch_name = dev.arch;
+    product_version = AMDeviceCopyValue(device, 0, CFSTR("ProductVersion"));
+    build_version = AMDeviceCopyValue(device, 0, CFSTR("BuildVersion"));
 
     NSLogVerbose(@"Hardware Model: %@", model);
     NSLogVerbose(@"Device Name: %@", device_name);
     NSLogVerbose(@"Model Name: %@", model_name);
     NSLogVerbose(@"SDK Name: %@", sdk_name);
     NSLogVerbose(@"Architecture Name: %@", arch_name);
+    NSLogVerbose(@"Product Version: %@", product_version);
+    NSLogVerbose(@"Build Version: %@", build_version);
 
     if (device_name != NULL) {
         full_name = CFStringCreateWithFormat(NULL, NULL, CFSTR("%@ (%@, %@, %@, %@) a.k.a. '%@'"), device_udid, model, model_name, sdk_name, arch_name, device_name);
@@ -393,6 +399,10 @@ CFStringRef get_device_full_name(const AMDeviceRef device) {
         CFRelease(model);
     if(model_name != NULL)
         CFRelease(model_name);
+    if(product_version)
+        CFRelease(product_version);
+    if(build_version)
+        CFRelease(build_version);
 
     return CFAutorelease(full_name);
 }

--- a/src/ios-deploy/ios-deploy.m
+++ b/src/ios-deploy/ios-deploy.m
@@ -91,6 +91,7 @@ char *bundle_id = NULL;
 bool interactive = true;
 bool justlaunch = false;
 bool file_system = false;
+bool non_recursively = false;
 char *app_path = NULL;
 char *app_deltas = NULL;
 char *device_id = NULL;
@@ -100,6 +101,7 @@ char *list_root = NULL;
 int _timeout = 0;
 int _detectDeadlockTimeout = 0;
 bool _json_output = false;
+NSMutableArray *_file_meta_info = nil;
 int port = 0;    // 0 means "dynamically assigned"
 CFStringRef last_path = NULL;
 service_conn_t gdbfd;
@@ -1300,15 +1302,53 @@ void read_dir(AFCConnectionRef afc_conn_p, const char* dir,
         // there was a problem reading or opening the file to get info on it, abort
         return;
     }
-
+    
+    long long mtime = -1;
+    long long birthtime = -1;
+    long size = -1;
+    long blocks = -1;
+    long nlink = -1;
+    NSString * ifmt = nil;
     while((AFCKeyValueRead(afc_dict_p,&key,&val) == 0) && key && val) {
         if (strcmp(key,"st_ifmt")==0) {
             not_dir = strcmp(val,"S_IFDIR");
-            break;
+            if (_json_output) {
+                ifmt = [NSString stringWithUTF8String:val];
+            } else {
+                break;
+            }
+        }
+        if (strcmp(key, "st_size") == 0) {
+            size = atol(val);
+        }
+        if (strcmp(key, "st_mtime") == 0) {
+            mtime = atoll(val);
+        }
+        if (strcmp(key, "st_birthtime") == 0) {
+            birthtime = atoll(val);
+        }
+        if (strcmp(key, "st_nlink") == 0) {
+            nlink = atol(val);
+        }
+        if (strcmp(key, "st_blocks") == 0) {
+            nlink = atol(val);
         }
     }
     AFCKeyValueClose(afc_dict_p);
-
+    
+    if (_json_output) {
+        if (_file_meta_info == nil) {
+            _file_meta_info = [[NSMutableArray alloc] init];
+        }
+        [_file_meta_info addObject: @{@"full_path": [NSString stringWithUTF8String:dir],
+                               @"st_ifmt": ifmt,
+                               @"st_nlink": @(nlink),
+                               @"st_size": @(size),
+                               @"st_blocks": @(blocks),
+                               @"st_mtime": @(mtime),
+                               @"st_birthtime": @(birthtime)}];
+    }
+    
     if (not_dir) {
         if (callback) (*callback)(afc_conn_p, dir, READ_DIR_FILE);
         return;
@@ -1342,7 +1382,9 @@ void read_dir(AFCConnectionRef afc_conn_p, const char* dir,
         if (dir_joined[strlen(dir)-1] != '/')
             strcat(dir_joined, "/");
         strcat(dir_joined, dir_ent);
-        read_dir(afc_conn_p, dir_joined, callback);
+        if (!(non_recursively && strcmp(list_root, dir) != 0)) {
+            read_dir(afc_conn_p, dir_joined, callback);
+        }
         free(dir_joined);
     }
 
@@ -1463,6 +1505,10 @@ void* read_file_to_memory(char const * path, size_t* file_size)
 
 void list_files_callback(AFCConnectionRef conn, const char *name, read_dir_cb_reason reason)
 {
+    if (_json_output) {
+        return;
+    }
+    
     if (reason == READ_DIR_FILE) {
         NSLogOut(@"%@", [NSString stringWithUTF8String:name]);
     } else if (reason == READ_DIR_BEFORE_DIR) {
@@ -1480,6 +1526,10 @@ void list_files(AMDeviceRef device)
     }
     assert(afc_conn_p);
     read_dir(afc_conn_p, list_root?list_root:"/", list_files_callback);
+    if (_json_output) {
+        NSLogJSON(@{@"Event": @"FileListed",
+                    @"Files": _file_meta_info});
+    }
     check_error(AFCConnectionClose(afc_conn_p));
 }
 
@@ -2115,6 +2165,7 @@ void usage(const char* app) {
         @"  -E, --error_output <file>    write stderr to this file\n"
         @"  --detect_deadlocks <sec>     start printing backtraces for all threads periodically after specific amount of seconds\n"
         @"  -f, --file_system            specify file system for mkdir / list / upload / download / rm\n"
+        @"  -F, --non-recursively        specify non-recursively walk directory\n"
         @"  -j, --json                   format output as JSON\n",
         [NSString stringWithUTF8String:app]);
 }
@@ -2174,7 +2225,7 @@ int main(int argc, char *argv[]) {
     };
     int ch;
 
-    while ((ch = getopt_long(argc, argv, "VmcdvunrILefD:R:X:i:b:a:t:p:1:2:o:l:w:9BWjNs:OE:CA:", longopts, NULL)) != -1)
+    while ((ch = getopt_long(argc, argv, "VmcdvunrILefFD:R:X:i:b:a:t:p:1:2:o:l:w:9BWjNs:OE:CA:", longopts, NULL)) != -1)
     {
         switch (ch) {
         case 'm':
@@ -2306,6 +2357,9 @@ int main(int argc, char *argv[]) {
             break;
         case 'f':
             file_system = true;
+            break;
+        case 'F':
+            non_recursively = true;
             break;
         default:
             usage(argv[0]);

--- a/src/ios-deploy/ios-deploy.m
+++ b/src/ios-deploy/ios-deploy.m
@@ -1500,10 +1500,6 @@ void* read_file_to_memory(char const * path, size_t* file_size)
 
 void list_files_callback(AFCConnectionRef conn, const char *name, read_dir_cb_reason reason)
 {
-    if (_json_output) {
-        return;
-    }
-    
     if (reason == READ_DIR_FILE) {
         NSLogOut(@"%@", [NSString stringWithUTF8String:name]);
     } else if (reason == READ_DIR_BEFORE_DIR) {
@@ -1520,11 +1516,14 @@ void list_files(AMDeviceRef device)
         afc_conn_p = start_house_arrest_service(device);
     }
     assert(afc_conn_p);
-    read_dir(afc_conn_p, list_root?list_root:"/", list_files_callback);
     if (_json_output) {
+        read_dir(afc_conn_p, list_root?list_root:"/", NULL);
         NSLogJSON(@{@"Event": @"FileListed",
                     @"Files": _file_meta_info});
+    } else {
+        read_dir(afc_conn_p, list_root?list_root:"/", list_files_callback);
     }
+    
     check_error(AFCConnectionClose(afc_conn_p));
 }
 

--- a/src/ios-deploy/ios-deploy.m
+++ b/src/ios-deploy/ios-deploy.m
@@ -1317,20 +1317,15 @@ void read_dir(AFCConnectionRef afc_conn_p, const char* dir,
             } else {
                 break;
             }
-        }
-        if (strcmp(key, "st_size") == 0) {
+        } else if (strcmp(key, "st_size") == 0) {
             size = atol(val);
-        }
-        if (strcmp(key, "st_mtime") == 0) {
+        } else if (strcmp(key, "st_mtime") == 0) {
             mtime = atoll(val);
-        }
-        if (strcmp(key, "st_birthtime") == 0) {
+        } else if (strcmp(key, "st_birthtime") == 0) {
             birthtime = atoll(val);
-        }
-        if (strcmp(key, "st_nlink") == 0) {
+        } else if (strcmp(key, "st_nlink") == 0) {
             nlink = atol(val);
-        }
-        if (strcmp(key, "st_blocks") == 0) {
+        } else if (strcmp(key, "st_blocks") == 0) {
             nlink = atol(val);
         }
     }
@@ -1341,12 +1336,12 @@ void read_dir(AFCConnectionRef afc_conn_p, const char* dir,
             _file_meta_info = [[NSMutableArray alloc] init];
         }
         [_file_meta_info addObject: @{@"full_path": [NSString stringWithUTF8String:dir],
-                               @"st_ifmt": ifmt,
-                               @"st_nlink": @(nlink),
-                               @"st_size": @(size),
-                               @"st_blocks": @(blocks),
-                               @"st_mtime": @(mtime),
-                               @"st_birthtime": @(birthtime)}];
+                                      @"st_ifmt": ifmt,
+                                      @"st_nlink": @(nlink),
+                                      @"st_size": @(size),
+                                      @"st_blocks": @(blocks),
+                                      @"st_mtime": @(mtime),
+                                      @"st_birthtime": @(birthtime)}];
     }
     
     if (not_dir) {

--- a/src/ios-deploy/ios-deploy.m
+++ b/src/ios-deploy/ios-deploy.m
@@ -1359,8 +1359,18 @@ AFCConnectionRef start_house_arrest_service(AMDeviceRef device) {
     }
 
     CFStringRef cf_bundle_id = CFStringCreateWithCString(NULL, bundle_id, kCFStringEncodingUTF8);
-    if (AMDeviceCreateHouseArrestService(device, cf_bundle_id, 0, &conn) != 0)
-    {
+    CFStringRef keys[1];
+    keys[0] = CFSTR("Command");
+    CFStringRef values[1];
+    values[0] = CFSTR("VendDocuments");
+    CFDictionaryRef command = CFDictionaryCreate(kCFAllocatorDefault,
+                                                 (void*)keys,
+                                                 (void*)values,
+                                                 1,
+                                                 &kCFTypeDictionaryKeyCallBacks,
+                                                 &kCFTypeDictionaryValueCallBacks);
+    if (AMDeviceCreateHouseArrestService(device, cf_bundle_id, 0, &conn) != 0 &&
+        AMDeviceCreateHouseArrestService(device, cf_bundle_id, command, &conn) != 0) {
         on_error(@"Unable to find bundle with id: %@", [NSString stringWithUTF8String:bundle_id]);
     }
 


### PR DESCRIPTION
# Add -F/--non-recursively option
Now by default, `ios-deploy` will walk the directory recursively .  In our practice , the directory structure may be very complicated and the file operation may cost a lot of time .  

In most cases we  only want to access some specific folder , hope this option may be helpful 

# Add --json support for list_file
Now list file  option only output the  path of the a file.  
We add `--json` support to get all the meta data of a file , like create time, file size , etc. The meta data will be organized as dictionary . 
![image](https://user-images.githubusercontent.com/4402159/77840215-71c65a80-71b7-11ea-9385-6f515c088614.png)
