### PR TITLE
fix communication with debuggserver on ios-14

### DIFF
--- a/src/ios-deploy/MobileDevice.h
+++ b/src/ios-deploy/MobileDevice.h
@@ -65,7 +65,14 @@ typedef unsigned int mach_error_t;
 
 typedef unsigned int afc_error_t;
 typedef unsigned int usbmux_error_t;
-typedef unsigned int service_conn_t;
+
+typedef struct {
+    char unknown[0x10];
+    int sockfd;
+    void * sslContext;
+    // ??
+} service_conn_t;
+
 typedef service_conn_t * ServiceConnRef;
 
 struct am_recovery_device;


### PR DESCRIPTION
Should fix #469 . 
If I did not mess anything up by merging changes this should work on older and newer ios devices.
Added also the version detection for tvOS, but I don't have a device to test this. 
