### PR TITLE
fix missing output when lldb is buffering output

### DIFF
--- a/src/scripts/lldb.py
+++ b/src/scripts/lldb.py
@@ -126,6 +126,7 @@ def autoexit_command(debugger, command, result, internal_dict):
             stderr = process.GetSTDERR(1024)
 
     def CloseOut():
+        sys.stdout.flush()
         if (out):
             out.close()
         if (err):


### PR DESCRIPTION
When lldb session is finished, in some cases the output seems to stay in buffer and never flushed, causing loss of stdout. 
stderr should be unaffected as it should never be buffered. 