### PR TITLE
Allocate ref on stack instead of the type itself for AFC service startup

### DIFF
--- a/src/ios-deploy/MobileDevice.h
+++ b/src/ios-deploy/MobileDevice.h
@@ -268,7 +268,7 @@ mach_error_t AMDeviceStartSession(struct am_device *device);
  */
 
 mach_error_t AMDeviceStartService(struct am_device *device, CFStringRef 
-    service_name, ServiceConnRef handle, unsigned int *
+    service_name, ServiceConnRef * handle, unsigned int *
     unknown);
 
 mach_error_t AMDeviceStartHouseArrestService(struct am_device *device, CFStringRef identifier, void *unknown, ServiceConnRef handle, unsigned int *what);
@@ -290,7 +290,7 @@ mach_error_t AMDeviceStopSession(struct am_device *device);
  *      MDERR_AFC_OUT_OF_MEMORY if malloc() failed
  */
 
-afc_error_t AFCConnectionOpen(service_conn_t handle, unsigned int io_timeout,
+afc_error_t AFCConnectionOpen(ServiceConnRef handle, unsigned int io_timeout,
     AFCConnectionRef *conn);
 
 /* Pass in a pointer to an afc_device_info structure. It will be filled. */

--- a/src/ios-deploy/ios-deploy.m
+++ b/src/ios-deploy/ios-deploy.m
@@ -1520,7 +1520,7 @@ AFCConnectionRef start_afc_service(AMDeviceRef device) {
     check_error(AMDeviceStartSession(device));
 
     AFCConnectionRef conn = NULL;
-    service_conn_t serviceConn;
+    ServiceConnRef serviceConn = NULL;
 
     if (AMDeviceStartService(device, AMSVC_AFC, &serviceConn, 0) != MDERR_OK) {
         on_error(@"Unable to start file service!");


### PR DESCRIPTION
Should fix #484 . 
Not sure how it worked before 8092250a3c36d34d392497c1824af23d8e24b66f. 

@ryanluoo , can you checks that it fixes issue for you also? 