### PR TITLE
Always emit "Symbol Path: ", even when running `--nolldb`

### DIFF
--- a/src/ios-deploy/ios-deploy.m
+++ b/src/ios-deploy/ios-deploy.m
@@ -504,7 +504,7 @@ CFMutableArrayRef copy_device_product_version_parts(AMDeviceRef device) {
 CFStringRef copy_device_support_path(AMDeviceRef device, CFStringRef suffix) {
     time_t startTime, endTime;
     time( &startTime );
-	
+    
     CFStringRef version = NULL;
     CFStringRef build = AMDeviceCopyValue(device, 0, CFSTR("BuildVersion"));
     CFStringRef deviceClass = AMDeviceCopyValue(device, 0, CFSTR("DeviceClass"));
@@ -596,7 +596,7 @@ CFStringRef copy_device_support_path(AMDeviceRef device, CFStringRef suffix) {
           @"Status": msg,
         });
         on_error(msg);
-	}
+    }
     
     time( &endTime );
     NSLogVerbose(@"DeviceSupport directory '%@' was located. It took %.2f seconds", path, difftime(endTime,startTime));

--- a/src/ios-deploy/ios-deploy.m
+++ b/src/ios-deploy/ios-deploy.m
@@ -504,7 +504,7 @@ CFMutableArrayRef copy_device_product_version_parts(AMDeviceRef device) {
 CFStringRef copy_device_support_path(AMDeviceRef device, CFStringRef suffix) {
     time_t startTime, endTime;
     time( &startTime );
-    
+	
     CFStringRef version = NULL;
     CFStringRef build = AMDeviceCopyValue(device, 0, CFSTR("BuildVersion"));
     CFStringRef deviceClass = AMDeviceCopyValue(device, 0, CFSTR("DeviceClass"));
@@ -596,7 +596,7 @@ CFStringRef copy_device_support_path(AMDeviceRef device, CFStringRef suffix) {
           @"Status": msg,
         });
         on_error(msg);
-    }
+	}
     
     time( &endTime );
     NSLogVerbose(@"DeviceSupport directory '%@' was located. It took %.2f seconds", path, difftime(endTime,startTime));
@@ -658,7 +658,14 @@ void mount_developer_image(AMDeviceRef device) {
         
         on_error(@"Unable to mount developer disk image. (%x)", result);
     }
-
+	
+	CFStringRef symbols_path = copy_device_support_path(device, CFSTR("Symbols"));
+	if (symbols_path != NULL)
+	{
+		NSLogOut(@"Symbol Path: %@", symbols_path);
+		CFRelease(symbols_path);
+	}
+	
     CFRelease(image_path);
     CFRelease(options);
 }

--- a/src/ios-deploy/ios-deploy.m
+++ b/src/ios-deploy/ios-deploy.m
@@ -659,12 +659,14 @@ void mount_developer_image(AMDeviceRef device) {
         on_error(@"Unable to mount developer disk image. (%x)", result);
     }
 	
-	CFStringRef symbols_path = copy_device_support_path(device, CFSTR("Symbols"));
-	if (symbols_path != NULL)
-	{
-		NSLogOut(@"Symbol Path: %@", symbols_path);
-		CFRelease(symbols_path);
-	}
+    CFStringRef symbols_path = copy_device_support_path(device, CFSTR("Symbols"));
+    if (symbols_path != NULL)
+    {
+        NSLogOut(@"Symbol Path: %@", symbols_path);
+        NSLogJSON(@{@"Event": @"MountDeveloperImage",
+                    @"SymbolsPath": (__bridge NSString *)symbols_path
+                    });		CFRelease(symbols_path);
+    }
 	
     CFRelease(image_path);
     CFRelease(options);


### PR DESCRIPTION
I'm using ios-deploy in a scenario where I attach the debugger myself, and having a way to be told the symbol path for that is incredibly useful (and should be no harm, otherwise)