### PR TITLE
Show iOS version and build version in "Device found" message

### DIFF
--- a/src/ios-deploy/ios-deploy.m
+++ b/src/ios-deploy/ios-deploy.m
@@ -2191,8 +2191,10 @@ void device_callback(struct am_device_notification_callback_info *info, void *ar
             break;
         case ADNCI_MSG_DISCONNECTED:
         {
+            CFStringRef device_interface_name = get_device_interface_name(info->dev);
             CFStringRef device_uuid = AMDeviceCopyDeviceIdentifier(info->dev);
-            NSLogOut(@"[....] Disconnected %@", device_uuid);
+            NSLogOut(@"[....] Disconnected %@ from %@.", device_uuid, device_interface_name);
+            CFRelease(device_interface_name);
             CFRelease(device_uuid);
             break;
         }

--- a/src/ios-deploy/ios-deploy.m
+++ b/src/ios-deploy/ios-deploy.m
@@ -2194,7 +2194,6 @@ void device_callback(struct am_device_notification_callback_info *info, void *ar
             CFStringRef device_interface_name = get_device_interface_name(info->dev);
             CFStringRef device_uuid = AMDeviceCopyDeviceIdentifier(info->dev);
             NSLogOut(@"[....] Disconnected %@ from %@.", device_uuid, device_interface_name);
-            CFRelease(device_interface_name);
             CFRelease(device_uuid);
             break;
         }

--- a/src/ios-deploy/ios-deploy.m
+++ b/src/ios-deploy/ios-deploy.m
@@ -504,7 +504,7 @@ CFMutableArrayRef copy_device_product_version_parts(AMDeviceRef device) {
 CFStringRef copy_device_support_path(AMDeviceRef device, CFStringRef suffix) {
     time_t startTime, endTime;
     time( &startTime );
-	
+    
     CFStringRef version = NULL;
     CFStringRef build = AMDeviceCopyValue(device, 0, CFSTR("BuildVersion"));
     CFStringRef deviceClass = AMDeviceCopyValue(device, 0, CFSTR("DeviceClass"));
@@ -596,7 +596,7 @@ CFStringRef copy_device_support_path(AMDeviceRef device, CFStringRef suffix) {
           @"Status": msg,
         });
         on_error(msg);
-	}
+    }
     
     time( &endTime );
     NSLogVerbose(@"DeviceSupport directory '%@' was located. It took %.2f seconds", path, difftime(endTime,startTime));

--- a/src/ios-deploy/ios-deploy.m
+++ b/src/ios-deploy/ios-deploy.m
@@ -412,11 +412,13 @@ CFStringRef get_device_full_name(const AMDeviceRef device) {
     NSLogVerbose(@"Architecture Name: %@", arch_name);
     NSLogVerbose(@"Product Version: %@", product_version);
     NSLogVerbose(@"Build Version: %@", build_version);
+    if (build_version == 0)
+        build_version = CFStringCreateWithCString(NULL, "", kCFStringEncodingUTF8);
 
     if (device_name != NULL) {
-        full_name = CFStringCreateWithFormat(NULL, NULL, CFSTR("%@ (%@, %@, %@, %@) a.k.a. '%@'"), device_udid, model, model_name, sdk_name, arch_name, device_name);
+        full_name = CFStringCreateWithFormat(NULL, NULL, CFSTR("%@ (%@, %@, %@, %@, %@, %@) a.k.a. '%@'"), device_udid, model, model_name, sdk_name, arch_name, product_version, build_version, device_name);
     } else {
-        full_name = CFStringCreateWithFormat(NULL, NULL, CFSTR("%@ (%@, %@, %@, %@)"), device_udid, model, model_name, sdk_name, arch_name);
+        full_name = CFStringCreateWithFormat(NULL, NULL, CFSTR("%@ (%@, %@, %@, %@, %@, %@)"), device_udid, model, model_name, sdk_name, arch_name, product_version, build_version);
     }
 
     AMDeviceDisconnect(device);

--- a/src/ios-deploy/ios-deploy.m
+++ b/src/ios-deploy/ios-deploy.m
@@ -504,7 +504,7 @@ CFMutableArrayRef copy_device_product_version_parts(AMDeviceRef device) {
 CFStringRef copy_device_support_path(AMDeviceRef device, CFStringRef suffix) {
     time_t startTime, endTime;
     time( &startTime );
-    
+	
     CFStringRef version = NULL;
     CFStringRef build = AMDeviceCopyValue(device, 0, CFSTR("BuildVersion"));
     CFStringRef deviceClass = AMDeviceCopyValue(device, 0, CFSTR("DeviceClass"));
@@ -596,7 +596,7 @@ CFStringRef copy_device_support_path(AMDeviceRef device, CFStringRef suffix) {
           @"Status": msg,
         });
         on_error(msg);
-    }
+	}
     
     time( &endTime );
     NSLogVerbose(@"DeviceSupport directory '%@' was located. It took %.2f seconds", path, difftime(endTime,startTime));
@@ -658,7 +658,14 @@ void mount_developer_image(AMDeviceRef device) {
         
         on_error(@"Unable to mount developer disk image. (%x)", result);
     }
-
+	
+	CFStringRef symbols_path = copy_device_support_path(device, CFSTR("Symbols"));
+	if (symbols_path != NULL)
+	{
+		NSLogOut(@"Symbol Path: %@", symbols_path);
+		CFRelease(symbols_path);
+	}
+	
     CFRelease(image_path);
     CFRelease(options);
 }

--- a/src/ios-deploy/ios-deploy.m
+++ b/src/ios-deploy/ios-deploy.m
@@ -659,12 +659,14 @@ void mount_developer_image(AMDeviceRef device) {
         on_error(@"Unable to mount developer disk image. (%x)", result);
     }
 	
-	CFStringRef symbols_path = copy_device_support_path(device, CFSTR("Symbols"));
-	if (symbols_path != NULL)
-	{
-		NSLogOut(@"Symbol Path: %@", symbols_path);
-		CFRelease(symbols_path);
-	}
+    CFStringRef symbols_path = copy_device_support_path(device, CFSTR("Symbols"));
+    if (symbols_path != NULL)
+    {
+        NSLogOut(@"Symbol Path: %@", symbols_path);
+        NSLogJSON(@{@"Event": @"MountDeveloperImage",
+                    @"SymbolsPath": (__bridge NSString *)symbols_path
+                    });		CFRelease(symbols_path);
+    }
 	
     CFRelease(image_path);
     CFRelease(options);


### PR DESCRIPTION
This is useful, e.g. for determining if a given device is eligible to run a certain project, depending on Target SDK/Deployment Target.