### PR TITLE
Add basic support for watchos

### DIFF
--- a/src/ios-deploy/MobileDevice.h
+++ b/src/ios-deploy/MobileDevice.h
@@ -201,9 +201,9 @@ void AMDSetLogLevel(int level);
  *      MDERR_OUT_OF_MEMORY if we ran out of memory
  */
 
-mach_error_t AMDeviceNotificationSubscribe(am_device_notification_callback
+mach_error_t AMDeviceNotificationSubscribeWithOptions(am_device_notification_callback
     callback, unsigned int unused0, unsigned int unused1, void* //unsigned int
-    dn_unknown3, struct am_device_notification **notification);
+    dn_unknown3, struct am_device_notification **notification, CFDictionaryRef options);
 
 
 /*  Connects to the iPhone. Pass in the am_device structure that the

--- a/src/ios-deploy/device_db.h
+++ b/src/ios-deploy/device_db.h
@@ -163,4 +163,8 @@ device_desc device_db[] = {
                           ADD_DEVICE("J33IAP", "Apple TV 3.1G",              "appletvos", "armv7"),
                           ADD_DEVICE("J42dAP", "Apple TV 4G",                "appletvos", "arm64"),
                           ADD_DEVICE("J105aAP","Apple TV 4K",                "appletvos", "arm64"),
+
+                          // Apple Watch
+                          ADD_DEVICE("N121sAP","Apple Watch Series 3 (GPS)", "watchos", "armv7k"),
+                          ADD_DEVICE("N157bAP","Apple Watch Series 6",       "watchos", "arm64"),
                           };


### PR DESCRIPTION
This still needs some testing on older macOS/iOS/Xcode versions, but created the PR to get some feedback.  

This PR should allow:
- Detecting watchOS devices connected trough iPhone
- Listing installed bundles
- Uninstalling/Installing on said watchOS device
- Starting debugger and application on said watchOS device

Looks like starting AFC service on watchOS is not possible, so copying files there and back again is also not possible. 
