### PR TITLE
Print uploaded files in verbose mode

### DIFF
--- a/src/ios-deploy/ios-deploy.m
+++ b/src/ios-deploy/ios-deploy.m
@@ -1949,6 +1949,9 @@ void upload_single_file(AMDeviceRef device, AFCConnectionRef afc_conn_p, NSStrin
     }
 
     NSLogVerbose(@"%@", destinationPath);
+    NSLogJSON(@{@"Event": @"UploadFile",
+                @"Destination": destinationPath
+                });
 
     int ret = AFCFileRefOpen(afc_conn_p, [destinationPath fileSystemRepresentation], 3, &file_ref);
     if (ret == 0x000a) {
@@ -1975,7 +1978,11 @@ void upload_dir(AMDeviceRef device, AFCConnectionRef afc_conn_p, NSString* sourc
         [[NSFileManager defaultManager] fileExistsAtPath: sourcePath isDirectory: &isDir];
         if (isDir)
         {
-            NSLogVerbose(@"%@/", destinationPath);
+            NSString *dirDestinationPath = [destinationPath stringByAppendingString:@"/"];
+            NSLogVerbose(@"%@", dirDestinationPath);
+            NSLogJSON(@{@"Event": @"UploadDir",
+                        @"Destination": dirDestinationPath
+                        });
             upload_dir(device, afc_conn_p, sourcePath, destinationPath);
         }
         else

--- a/src/ios-deploy/ios-deploy.m
+++ b/src/ios-deploy/ios-deploy.m
@@ -1948,6 +1948,7 @@ void upload_single_file(AMDeviceRef device, AFCConnectionRef afc_conn_p, NSStrin
         check_error(AFCDirectoryCreate(afc_conn_p, [dirpath fileSystemRepresentation]));
     }
 
+    NSLogVerbose(@"%@", destinationPath);
 
     int ret = AFCFileRefOpen(afc_conn_p, [destinationPath fileSystemRepresentation], 3, &file_ref);
     if (ret == 0x000a) {
@@ -1974,6 +1975,7 @@ void upload_dir(AMDeviceRef device, AFCConnectionRef afc_conn_p, NSString* sourc
         [[NSFileManager defaultManager] fileExistsAtPath: sourcePath isDirectory: &isDir];
         if (isDir)
         {
+            NSLogVerbose(@"%@/", destinationPath);
             upload_dir(device, afc_conn_p, sourcePath, destinationPath);
         }
         else


### PR DESCRIPTION
This logs the uploaded directories and files in the verbose mode (`-v`)
similar to logging the downloaded directories and files (however that
doesn't require the verbose mode).

Fixes #519.

For example:
```bash
$ ./ios-deploy -v -1 io.realm.Simple --upload=$HOME/Desktop/simple --to=/
[....] Waiting for iOS device to be connected
Handling device type: 1
Already found device? 0
Hardware Model: J72bAP
Device Name: iPadw
Model Name: iPad (2018)
SDK Name: iphoneos
Architecture Name: arm64
Product Version: 14.4.1
Build Version: 18D61
[....] Using X (J72bAP, iPad (2018), iphoneos, arm64, 14.4.1, 18D61) a.k.a. 'iPad'.
/Library/
/Library/Saved Application State/
/Library/Saved Application State/io.realm.Simple.savedState/
/Library/Saved Application State/io.realm.Simple.savedState/KnownSceneSessions/
/Library/Saved Application State/io.realm.Simple.savedState/KnownSceneSessions/data.data
/Library/Preferences/
/Library/SplashBoard/
/Library/SplashBoard/Snapshots/
/Library/SplashBoard/Snapshots/io.realm.Simple - {DEFAULT GROUP}/
/Library/SplashBoard/Snapshots/io.realm.Simple - {DEFAULT GROUP}/9B15514B-5DCB-4A37-8F2A-33A23A9451A7@2x.ktx
/Library/SplashBoard/Snapshots/io.realm.Simple - {DEFAULT GROUP}/downscaled/
/Library/SplashBoard/Snapshots/io.realm.Simple - {DEFAULT GROUP}/downscaled/86A9F37C-EB1B-41BD-B352-B0F85280179B@2x.ktx
/Library/Caches/
/Library/Caches/io.realm.Simple/
/Library/Caches/io.realm.Simple/Cache.db-shm
/Library/Caches/io.realm.Simple/com.apple.metalfe/
/Library/Caches/io.realm.Simple/Cache.db-wal
/Library/Caches/io.realm.Simple/Cache.db
/Documents/
/Documents/default.realm.management/
/Documents/default.realm.management/access_control.write.mx
/Documents/default.realm.management/access_control.control.mx
/Documents/default.realm
/Documents/default.realm.lock
/tmp/
```