### PR TITLE
Skip removing FIFOs from device

### DIFF
--- a/src/ios-deploy/errors.h
+++ b/src/ios-deploy/errors.h
@@ -511,9 +511,14 @@ const int error_id_to_message_count = sizeof(error_id_to_message) / sizeof(error
 const char* get_error_message(unsigned int error) {
 	const char* id = NULL;
 
+	// this creates an error code to match what's defined in `errorcode_to_id`;
+	// taken from https://github.com/samdmarshall/SDMMobileDevice/blob/c3e1e97b1310c7a7a10f68281752760038b75e16/Framework/include/SDMMobileDevice/SDMMD_Error.h#L512
+	// note that the `error & 0xff` isn't done here because there are defined errors like `0xe8008001`
+	const unsigned int error_code = error | 0xe8000000;
+
 	// Lookup error localization id
 	for (int i = 0; i < errorcode_to_id_count; i++) {
-		if (errorcode_to_id[i].error == error) {
+		if (errorcode_to_id[i].error == error_code) {
 			id = errorcode_to_id[i].id;
 			break;
 		}

--- a/src/ios-deploy/ios-deploy.m
+++ b/src/ios-deploy/ios-deploy.m
@@ -1533,6 +1533,7 @@ void read_dir(AFCConnectionRef afc_conn_p, const char* dir,
     afc_dictionary* afc_dict_p;
     char *key, *val;
     int not_dir = 0;
+    bool is_fifo = 0;
 
     unsigned int code = AFCFileInfoOpen(afc_conn_p, dir, &afc_dict_p);
     if (code != 0) {
@@ -1549,6 +1550,7 @@ void read_dir(AFCConnectionRef afc_conn_p, const char* dir,
     while((AFCKeyValueRead(afc_dict_p,&key,&val) == 0) && key && val) {
         if (strcmp(key,"st_ifmt")==0) {
             not_dir = strcmp(val,"S_IFDIR");
+            is_fifo = !strcmp(val, "S_IFIFO");
             if (_json_output) {
                 ifmt = [NSString stringWithUTF8String:val];
             } else {


### PR DESCRIPTION
That operation always fails with error `0xc` anyway.

To distinguish regular files from FIFO, new `READ_DIR_FIFO` is added to
`read_dir_cb_reason`. The behavior of other operations regarding FIFOs
is left the same by supporting the new reason.

(Another implementation could be not to extend the `read_dir_cb_reason`
and add another flag to `read_dir`'s `callback`, but that would allow
meaningless cases, such as `reason = READ_DIR_AFTER_DIR, is_fifo =
true`.

The ideal implementation would be to extent the `READ_DIR_FILE` enum
case with a flag (i.e., `READ_DIR_FILE(is_fifo = true)`), but that is
not supported in Objective-C.)

The fix is to skip removing FIFOs had a side-effect of failing to remove
a directory where a skipped file is because the directory is not empty.

The change here is to continue removing files after errors, which is
also helpful in cases when `ios-deploy` fails to remove `/Documents/`
("Error 0xa: You do not have permission."), but still needs to continue
removing what it can from `/Library/`.

Fixes #518.

## Error messages

I've also stumbled upon a fix for error messages (I can extract it to a new PR if necessary):

This makes `ios-deploy` print error messages for known error codes so
that the console log looks like:

```
ios-deploy[13450:4855044] [ !! ] Error 0x1: An unknown error occurred. AFCRemovePath(conn, name)
ios-deploy[13450:4855044] [ !! ] Error 0xa: You do not have permission. AFCRemovePath(conn, name)
```

instead of:

```
ios-deploy[13409:4853438] [ !! ] Error 0x1: unknown. AFCRemovePath(conn, name)
ios-deploy[13409:4853438] [ !! ] Error 0xa: unknown. AFCRemovePath(conn, name)
```

The fix is to create an error code from the input `error` to match
what's defined in `errorcode_to_id` (for some reason, the errors are
`OR`'d with `0xe8000000`). This change is taken from the
`SDMMobileDevice` project, which is the source for the error codes.

## Sample output now

```
$ ios-deploy -1 io.realm.Simple --rmtree /
[....] Waiting for iOS device to be connected
[....] Using X (J72bAP, iPad (2018), iphoneos, arm64, 14.4.1, 18D61) a.k.a. 'iPad'.
2021-07-26 16:48:58.257 ios-deploy[15159:4903131] [ !! ] Error 0x1: An unknown error occurred. AFCRemovePath(conn, name)
2021-07-26 16:48:58.294 ios-deploy[15159:4903131] [ !! ] Error 0xa: You do not have permission. AFCRemovePath(conn, name)
2021-07-26 16:48:58.363 ios-deploy[15159:4903131] [ !! ] Error 0xa: You do not have permission. AFCRemovePath(conn, name)
2021-07-26 16:48:58.469 ios-deploy[15159:4903131] [ !! ] Error 0xa: You do not have permission. AFCRemovePath(conn, name)
2021-07-26 16:48:58.477 ios-deploy[15159:4903131] [ !! ] Error 0xa: You do not have permission. AFCRemovePath(conn, name)
2021-07-26 16:48:58.497 ios-deploy[15159:4903131] [ !! ] Error 0xa: You do not have permission. AFCRemovePath(conn, name)

$ ios-deploy -1 io.realm.Simple -v --rmtree /
[....] Waiting for iOS device to be connected
Handling device type: 1
Already found device? 0
Hardware Model: J72bAP
Device Name: iPad
Model Name: iPad (2018)
SDK Name: iphoneos
Architecture Name: arm64
Product Version: 14.4.1
Build Version: 18D61
[....] Using X (J72bAP, iPad (2018), iphoneos, arm64, 14.4.1, 18D61) a.k.a. 'iPad'.
Skipping /Documents/default.realm.management/lock.fifo
Skipping /Documents/default.realm.management/access_control.write.mx.fifo
Skipping /Documents/default.realm.management/access_control.new_commit.cv
Deleting /Documents/default.realm.management/access_control.write.mx
Deleting /Documents/default.realm.management/access_control.control.mx
Skipping /Documents/default.realm.management/access_control.pick_writer.cv
Skipping /Documents/default.realm.management/access_control.control.mx.fifo
Deleting /Documents/default.realm.management
2021-07-26 16:49:33.700 ios-deploy[15616:4907374] [ !! ] Error 0x1: An unknown error occurred. AFCRemovePath(conn, name)
Deleting /Documents/default.realm
Deleting /Documents/default.realm.lock
Skipping /Documents/default.realm.note
Deleting /Documents
2021-07-26 16:49:33.732 ios-deploy[15616:4907374] [ !! ] Error 0xa: You do not have permission. AFCRemovePath(conn, name)
Deleting /Library/Caches/io.realm.Simple/com.apple.metalfe
Deleting /Library/Caches/io.realm.Simple/Cache.db
Deleting /Library/Caches/io.realm.Simple/Cache.db-wal
Deleting /Library/Caches/io.realm.Simple/Cache.db-shm
Deleting /Library/Caches/io.realm.Simple
Deleting /Library/Caches
2021-07-26 16:49:33.810 ios-deploy[15616:4907374] [ !! ] Error 0xa: You do not have permission. AFCRemovePath(conn, name)
Deleting /Library/Saved Application State/io.realm.Simple.savedState/KnownSceneSessions/data.data
Deleting /Library/Saved Application State/io.realm.Simple.savedState/KnownSceneSessions
Deleting /Library/Saved Application State/io.realm.Simple.savedState
Deleting /Library/Saved Application State
Deleting /Library/SplashBoard/Snapshots/io.realm.Simple - {DEFAULT GROUP}/E477E795-9DCD-4D7C-8419-E70B3A240F30@2x.ktx
Deleting /Library/SplashBoard/Snapshots/io.realm.Simple - {DEFAULT GROUP}/downscaled/563F34C5-8A7E-4AEF-8ECA-4CBD26879FAA@2x.ktx
Deleting /Library/SplashBoard/Snapshots/io.realm.Simple - {DEFAULT GROUP}/downscaled
Deleting /Library/SplashBoard/Snapshots/io.realm.Simple - {DEFAULT GROUP}
Deleting /Library/SplashBoard/Snapshots
Deleting /Library/SplashBoard
Deleting /Library/Preferences
2021-07-26 16:49:33.920 ios-deploy[15616:4907374] [ !! ] Error 0xa: You do not have permission. AFCRemovePath(conn, name)
Deleting /Library
2021-07-26 16:49:33.927 ios-deploy[15616:4907374] [ !! ] Error 0xa: You do not have permission. AFCRemovePath(conn, name)
Deleting /tmp
Deleting /
2021-07-26 16:49:33.947 ios-deploy[15616:4907374] [ !! ] Error 0xa: You do not have permission. AFCRemovePath(conn, name)
```