### PR TITLE
Correct read_dir(...) nlink/blocks reporting

### DIFF
--- a/src/ios-deploy/ios-deploy.m
+++ b/src/ios-deploy/ios-deploy.m
@@ -1563,7 +1563,7 @@ void read_dir(AFCConnectionRef afc_conn_p, const char* dir,
         } else if (strcmp(key, "st_nlink") == 0) {
             nlink = atol(val);
         } else if (strcmp(key, "st_blocks") == 0) {
-            nlink = atol(val);
+            blocks = atol(val);
         }
     }
     AFCKeyValueClose(afc_dict_p);


### PR DESCRIPTION
When requested via "--list --json", read_dir(...) loops thru AFCKeyValueRead(...) to obtain st_size/st_mtime/st_birthtime/st_nlink/st_blocks of each directory entry. Likely typo had st_nlink value being overwritten by st_blocks causing reported "st_nlink" to match st_blocks and st_blocks always be "-1". Fix corrects this typo and now both values are being reported correctly.