### PR TITLE
Restore behaviour where DEVELOPER_DIR pointing not Xcode.app still works

### DIFF
--- a/src/ios-deploy/ios-deploy.m
+++ b/src/ios-deploy/ios-deploy.m
@@ -359,6 +359,15 @@ CFStringRef copy_xcode_dev_path(void) {
         
         if (env_dev_path && strlen(env_dev_path) > 0) {
             strcpy(xcode_dev_path, env_dev_path);
+            // DEVELOPER_DIR should refer to Xcode.app/Contents/Developer, but
+            // xcode-select and friends have an extension to fix the path, if it points to Xcode.app/.
+            static char dev_subdir[256] = { '\0' };
+            strcat(strcat(dev_subdir, env_dev_path), "/Contents/Developer");
+            struct stat sb;
+            if (stat(dev_subdir, &sb) == 0)
+            {
+                strcpy(xcode_dev_path, dev_subdir);
+            }
         } else {
             FILE *fpipe = NULL;
             char *command = "xcode-select -print-path";


### PR DESCRIPTION
xcode-select is able to handle DEVELOPER_DIR pointing to Xcode.app even though
historically it should be pointing to the Contents/Developer sub directory.
This PR restores previous behaviour where setting DEVELOPER_DIR to root xcode folder still works in ios-deploy.

From the `xcode-select` man page:

> Note that for historical reason, the developer directory is considered to be the Developer content directory inside the  Xcode application (for example /Applications/Xcode.app/Contents/Developer). You can set the environment variable to either the actual Developer contents directory, or the Xcode application directory -- the xcode-select provided shims will automatically convert the environment variable into the full Developer content path.

