### PR TITLE
Skipping no reason stops in --non-interact lldb script

### DIFF
--- a/src/scripts/lldb.py
+++ b/src/scripts/lldb.py
@@ -156,6 +156,11 @@ def autoexit_command(debugger, command, result, internal_dict):
             CloseOut()
             os._exit(process.GetExitStatus())
         elif printBacktraceTime is None and state == lldb.eStateStopped:
+            selectedThread = process.GetSelectedThread()
+            if selectedThread.GetStopReason() == lldb.eStopReasonNone:
+                # During startup there are some stops for lldb to setup properly.
+                # On iOS-16 we receive them with stop reason none.
+                continue
             sys.stdout.write( '\\nPROCESS_STOPPED\\n' )
             debugger.HandleCommand('bt')
             CloseOut()


### PR DESCRIPTION
Combination of lldb in Xcode-14 and iOS-16 beta currently forwards these events to our handler, which
causes premature exit for the non interact script. Crashes and signals have a reason.